### PR TITLE
feat: 新增 ChatAnywhere 平台余额查询支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   - 🦈 **DeepSeek (深度求索)**
   - 🌙 **Moonshot AI (Kimi)**
   - ☁️ **SiliconCloud (硅基流动)**
+  - 🌍 **ChatAnywhere**
 - **权限控制**：支持配置仅管理员可用，保护账户隐私。
 - **安全日志**：日志中自动脱敏 API Key，防止泄露。
 

--- a/fetchers/__init__.py
+++ b/fetchers/__init__.py
@@ -2,5 +2,6 @@ from .base import BaseBalanceFetcher
 from .deepseek import DeepSeekFetcher
 from .moonshot import MoonshotFetcher
 from .siliconflow import SiliconCloudFetcher
+from .chatanywhere import ChatAnywhereFetcher
 
-__all__ = ["BaseBalanceFetcher", "DeepSeekFetcher", "MoonshotFetcher", "SiliconCloudFetcher"]
+__all__ = ["BaseBalanceFetcher", "DeepSeekFetcher", "MoonshotFetcher", "SiliconCloudFetcher", "ChatAnywhereFetcher"]

--- a/fetchers/chatanywhere.py
+++ b/fetchers/chatanywhere.py
@@ -1,0 +1,80 @@
+import aiohttp
+from datetime import datetime, timedelta
+from ..models import BalanceResult
+from .base import BaseBalanceFetcher
+
+class ChatAnywhereFetcher(BaseBalanceFetcher):
+    def match(self, api_base: str) -> bool:
+        return "chatanywhere" in api_base
+
+    async def fetch(self, session: aiohttp.ClientSession, api_key: str, api_base: str) -> BalanceResult:
+        # 处理 api_base，确保指向根域名
+        # 例如 https://api.chatanywhere.tech/v1 -> https://api.chatanywhere.tech
+        base_url = api_base
+        if "/v1" in base_url:
+            base_url = base_url.split("/v1")[0]
+        
+        # 1. 获取订阅信息 (总额度)
+        sub_url = f"{base_url}/v1/dashboard/billing/subscription"
+        headers = {
+            'Authorization': f'Bearer {api_key}'
+        }
+        
+        total_balance = 0.0
+        currency = "USD"
+        
+        try:
+            async with session.get(sub_url, headers=headers) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    # ChatAnywhere 通常返回 hard_limit_usd
+                    total_balance = data.get("hard_limit_usd", 0.0)
+                else:
+                    # 如果获取订阅失败，可能是不支持该接口，尝试继续
+                    pass
+        except Exception as e:
+            pass
+
+        # 2. 获取使用量 (已用额度)
+        # 通常需要查询当月的使用量，或者从很久以前到现在
+        usage_url = f"{base_url}/v1/dashboard/billing/usage"
+        
+        # 查询最近 100 天的使用量 (覆盖足够长的时间)
+        end_date = datetime.now()
+        start_date = end_date - timedelta(days=99)
+        
+        params = {
+            "start_date": start_date.strftime("%Y-%m-%d"),
+            "end_date": end_date.strftime("%Y-%m-%d")
+        }
+        
+        used_balance = 0.0
+        
+        try:
+            async with session.get(usage_url, headers=headers, params=params) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    # total_usage 是美分，需要除以 100
+                    total_usage_cents = data.get("total_usage", 0)
+                    used_balance = total_usage_cents / 100
+                else:
+                    # 如果获取使用量失败
+                    pass
+        except Exception as e:
+            pass
+
+        # 计算剩余额度
+        remaining = total_balance - used_balance
+        
+        # 如果获取到的都是 0，且没有报错，可能是不支持
+        if total_balance == 0 and used_balance == 0:
+             return BalanceResult("ChatAnywhere", "Unknown", "0", error="无法获取余额信息 (API不支持或返回为空)")
+
+        return BalanceResult(
+            source_name="ChatAnywhere",
+            currency=currency,
+            total_balance=f"{total_balance:.2f}",
+            remaining_balance=f"{remaining:.2f}",
+            used_balance=f"{used_balance:.2f}",
+            raw_info=""
+        )

--- a/manager.py
+++ b/manager.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 import aiohttp
 from .models import BalanceResult
-from .fetchers import BaseBalanceFetcher, DeepSeekFetcher, MoonshotFetcher, SiliconCloudFetcher
+from .fetchers import BaseBalanceFetcher, DeepSeekFetcher, MoonshotFetcher, SiliconCloudFetcher, ChatAnywhereFetcher
 
 class BalanceManager:
     def __init__(self):
@@ -9,6 +9,7 @@ class BalanceManager:
             DeepSeekFetcher(),
             MoonshotFetcher(),
             SiliconCloudFetcher(),
+            ChatAnywhereFetcher(),
         ]
         self._session: Optional[aiohttp.ClientSession] = None
 


### PR DESCRIPTION
## 描述
新增了对 ChatAnywhere (api.chatanywhere.tech) 平台的余额查询支持。

## 变更内容
1. 新增 `fetchers/chatanywhere.py`，实现了 `ChatAnywhereFetcher`。
   - 支持自动识别 `chatanywhere` 相关的 API Base。
   - 通过 `/v1/dashboard/billing/subscription` 获取总额度。
   - 通过 `/v1/dashboard/billing/usage` 获取已用额度。
2. 修改 `fetchers/__init__.py`，导出 `ChatAnywhereFetcher`。
3. 修改 `manager.py`，注册 `ChatAnywhereFetcher`。
4. 更新 `README.md`，添加 ChatAnywhere 支持说明。